### PR TITLE
Add pointfree function

### DIFF
--- a/lib/f.mjs
+++ b/lib/f.mjs
@@ -10,7 +10,8 @@ export {
   flip,
   compose,
   pipe,
-  merge
+  merge,
+  pointfree
 }
 
 export default {
@@ -18,5 +19,6 @@ export default {
   flip,
   compose,
   pipe,
-  merge
+  merge,
+  pointfree
 }

--- a/lib/f.mjs
+++ b/lib/f.mjs
@@ -3,6 +3,7 @@ import flip from './flip.mjs'
 import compose from './compose.mjs'
 import pipe from './pipe.mjs'
 import merge from './merge.mjs'
+import pointfree from './pointfree'
 
 export {
   curry,

--- a/lib/pointfree.doc.md
+++ b/lib/pointfree.doc.md
@@ -1,6 +1,6 @@
 # pointfree
 
-Pointfree takes a string and optional integer. The string should be a method name on an existing object. The integer specifies the arity of the method (the number of expected arguments) and defaults to 1. It returns a curried function that accepts the specified number of arguments followed by the object containing the method. After all parameters are received it will call the method with the provided arguments.
+Pointfree takes a string and optional integer. The string should be a method name on an existing object. The integer specifies the arity of the method (the number of expected arguments) and defaults to 1. It returns a curried function that accepts the specified number of arguments followed by the object containing the method. After all parameters are received it will call the method with the provided arguments and return the result.
 
 ```javascript
 

--- a/lib/pointfree.doc.md
+++ b/lib/pointfree.doc.md
@@ -1,0 +1,37 @@
+# pointfree
+
+Pointfree takes a string and optional integer. The string should be a method name on an existing object. The integer specifies the arity of the method (the number of expected arguments) and defaults to 1. It returns a curried function that accepts the specified number of arguments followed by the object containing the method. After all parameters are received it will call the method with the provided arguments.
+
+```javascript
+
+import { pointfree, curry } from 'lb-f'
+
+const map = pointfree('map')
+const reduce = pointfree('reduce', 2)
+
+const array = [1, 2, 3]
+const add = curry( (a, b) => a + b )
+const add1 = add(1)
+
+map(add1, array) // [2, 3, 4]
+reduce(add, 0, array) // 6
+
+```
+
+## In the real world
+
+Pointfree can be used to easily convert easily convert methods on arrays or other objects to a point free style.
+
+TODO: more detail
+
+```javascript
+// TODO: example code
+```
+
+## How it works
+
+TODO: explain the internals (it's almost the same as curry)
+
+```javascript
+// TODO: step through example
+```

--- a/lib/pointfree.mjs
+++ b/lib/pointfree.mjs
@@ -1,0 +1,9 @@
+const pointfree = (m, arity = 1) => {
+  const pointfreeCurry = (...args) =>
+    args.length >= arity + 1
+      ? args[arity][m](...args.slice(0, arity))
+      : (...moreArgs) => pointfreeCurry(...args, ...moreArgs)
+  return pointfreeCurry
+}
+
+export default pointfree

--- a/lib/pointfree.mjs
+++ b/lib/pointfree.mjs
@@ -1,7 +1,7 @@
-const pointfree = (m, arity = 1) => {
+const pointfree = (method, arity = 1) => {
   const pointfreeCurry = (...args) =>
     args.length >= arity + 1
-      ? args[arity][m](...args.slice(0, arity))
+      ? args[arity][method](...args.slice(0, arity))
       : (...moreArgs) => pointfreeCurry(...args, ...moreArgs)
   return pointfreeCurry
 }

--- a/lib/pointfree.test.js
+++ b/lib/pointfree.test.js
@@ -1,0 +1,23 @@
+const load = require('@std/esm')(module)
+const test = require('ava')
+const pointfree = load('./pointfree.mjs').default
+
+test('pointfree', t => {
+  const obj = {
+    arity1method: x => x,
+    arity2method: (x, y) => x + y,
+    arity3method: (x, y, z) => x + y + z
+  }
+
+  const single = pointfree('arity1method')
+  t.is(single(1, obj), 1, 'calls arity 1 method with provided parameter')
+  t.is(single(11)(obj), 11, 'works with arity 1 method when arguments given one at a time')
+
+  const double = pointfree('arity2method', 2)
+  t.is(double(2, 2, obj), 4, 'calls arity 2 method with provided parameters')
+  t.is(double(22)(22)(obj), 44, 'works with arity 2 method when arguments given one at a time')
+
+  const triple = pointfree('arity3method', 3)
+  t.is(triple(3, 3, 3, obj), 9, 'calls arity 3 method with provided parameters')
+  t.is(triple(33)(33)(33)(obj), 99, 'works with arity 3 method when arguments given one at a time')
+})


### PR DESCRIPTION
Pointfree provides a simple way to make point-free callers of object methods. The original intent of this function was to call functor methods such as map or reduce on arrays, but the result can call any object's methods with any argument type.