### PR TITLE
 Implement Maybe as classes plus helper functions

### DIFF
--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,0 +1,26 @@
+import curry from './curry.mjs'
+
+const maybe = x => {
+  const contents = x
+
+  const isNothing = () =>
+    contents === null || contents === undefined
+
+  const map = fn =>
+    maybe(isNothing() ? null : fn(contents))
+
+  const open = curry(
+    (isEmpty, fn) =>
+      isNothing()
+        ? isEmpty
+        : fn(contents)
+  )
+
+  return {
+    isNothing,
+    map,
+    open
+  }
+}
+
+export default maybe

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,26 +1,43 @@
 import curry from './curry.mjs'
 
-const maybe = x => {
-  const contents = x
+export const Null = Object.freeze(Object.create(null))
 
-  const isNothing = () =>
-    contents === null || contents === undefined
-
-  const map = fn =>
-    maybe(isNothing() ? null : fn(contents))
-
-  const open = curry(
-    (isEmpty, fn) =>
-      isNothing()
-        ? isEmpty
-        : fn(contents)
-  )
-
-  return {
-    isNothing,
-    map,
-    open
-  }
+export function Maybe (x) {
+  this.x = x
 }
 
-export default maybe
+export function Nothing () {
+  Maybe.call(this, Null)
+  this.toString = () => 'Nothing'
+}
+Nothing.prototype = Object.create(Maybe.prototype)
+Nothing.prototype.constructor = Nothing
+Nothing.prototype.map = () => nothing
+
+export function Just (x) {
+  // For convenience, fail silently by converting to Nothing
+  if (x === null || x === undefined) {
+    return nothing
+  }
+  Maybe.call(this, x)
+  this.toString = () => `Just(${this.x})`
+}
+Just.prototype = Object.create(Maybe.prototype)
+Just.prototype.constructor = Just
+Just.prototype.map = function (f) {
+  const y = f(this.x)
+  return (y === null || y === undefined)
+    ? nothing
+    : new Just(y)
+}
+
+export const just = x => new Just(x)
+export const isJust = m => m instanceof Just
+
+export const nothing = new Nothing()
+export const isNothing = m => m instanceof Nothing
+
+export const maybe = curry((fallback, f, maybeInstance) =>
+  isNothing(maybeInstance)
+    ? fallback
+    : f(maybeInstance.x))

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,46 +1,35 @@
 const load = require('@std/esm')(module)
 const test = require('ava')
-const maybe = load('./maybe.mjs').default
-const curry = load('./curry.mjs').default
+const {
+  isJust,
+  isNothing,
+  just,
+  nothing,
+  maybe,
+  Maybe
+} = load('./maybe.mjs')
 
-test('maybe.open', t => {
-  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
-  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+const id = x => x
+
+test('nothing', t => {
+  t.is(nothing instanceof Maybe, true, 'is a Maybe')
+  t.is(isNothing(nothing), true, 'is nothing')
+  t.is(isJust(nothing), false, 'is not a just')
+  t.is(isNothing(nothing.map(id)), true, 'maps back to a Nothing')
 })
 
-test('maybe.isNothing', t => {
-  t.is(maybe(4).isNothing(), false, 'a value is something')
-  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
-  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
-  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
-  t.is(maybe(null).isNothing(), true, 'null is nothing')
-  t.is(maybe().isNothing(), true, 'undefined is nothing')
+test('just', t => {
+  t.is(just(1) instanceof Maybe, true, 'is a Maybe')
+  t.is(isNothing(just(2)), false, 'is not nothing')
+  t.is(isJust(just(3)), true, 'is a just')
+  t.is(isNothing(just(null)), true, 'converts bad Just to a Nothing')
+  t.is(isJust(just(4).map(id)), true, 'maps to a Just for good fn return')
+  t.is(isJust(just(5).map(id)), true, 'maps back to a Just for good value')
+  t.is(isNothing(just(6).map(() => null)), true, 'maps to Nothing for bad fn return')
 })
 
-test('maybe map', t => {
-  const add = curry((a, b) => a + b)
-
-  t.is(
-    maybe(5)
-      .map(add(10))
-      .open('isEmpty', x => x),
-    15,
-    'mapping functions should create a new maybe'
-  )
-
-  t.is(
-    maybe(2)
-      .map(add(1))
-      .open('isEmpty', x => x),
-    3,
-    'mapping functions should create an new maybe'
-  )
-
-  t.is(
-    maybe()
-      .map(add(4))
-      .open('isEmpty', x => x),
-    'isEmpty',
-    'mapping nothing should return maybe nothing'
-  )
+test('maybe', t => {
+  t.is(maybe(0, id, nothing), 0, 'resolves nothing to fallback value')
+  t.is(maybe(0)(id)(nothing), 0, 'is curried')
+  t.is(maybe(0, id, just(42)), 42, 'resolves just to result of fn called with internal value')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,0 +1,46 @@
+const load = require('@std/esm')(module)
+const test = require('ava')
+const maybe = load('./maybe.mjs').default
+const curry = load('./curry.mjs').default
+
+test('maybe.open', t => {
+  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
+  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+})
+
+test('maybe.isNothing', t => {
+  t.is(maybe(4).isNothing(), false, 'a value is something')
+  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
+  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
+  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
+  t.is(maybe(null).isNothing(), true, 'null is nothing')
+  t.is(maybe().isNothing(), true, 'undefined is nothing')
+})
+
+test('maybe map', t => {
+  const add = curry((a, b) => a + b)
+
+  t.is(
+    maybe(5)
+      .map(add(10))
+      .open('isEmpty', x => x),
+    15,
+    'mapping functions should create a new maybe'
+  )
+
+  t.is(
+    maybe(2)
+      .map(add(1))
+      .open('isEmpty', x => x),
+    3,
+    'mapping functions should create an new maybe'
+  )
+
+  t.is(
+    maybe()
+      .map(add(4))
+      .open('isEmpty', x => x),
+    'isEmpty',
+    'mapping nothing should return maybe nothing'
+  )
+})


### PR DESCRIPTION
Here is another take on Maybe. This is a first pass at trying to implement this as I described in my comments to #13.

Not a huge fan of using classes, but it's the only way I know of to define new _verifiable_ types in vanilla js.

Note that the design abstracts the class interface away from the user. Typical usage should not require importing the classes themselves unless you need to do type checking (for example type signatures in TypeScript).

Thoughts?