### PR TITLE
 Implement maybe as plain JS objects

### DIFF
--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,0 +1,26 @@
+import curry from './curry.mjs'
+
+const maybe = x => {
+  const contents = x
+
+  const isNothing = () =>
+    contents === null || contents === undefined
+
+  const map = fn =>
+    maybe(isNothing() ? null : fn(contents))
+
+  const open = curry(
+    (isEmpty, fn) =>
+      isNothing()
+        ? isEmpty
+        : fn(contents)
+  )
+
+  return {
+    isNothing,
+    map,
+    open
+  }
+}
+
+export default maybe

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,26 +1,43 @@
 import curry from './curry.mjs'
 
-const maybe = x => {
-  const contents = x
+export const Null = Object.freeze(Object.create(null))
 
-  const isNothing = () =>
-    contents === null || contents === undefined
-
-  const map = fn =>
-    maybe(isNothing() ? null : fn(contents))
-
-  const open = curry(
-    (isEmpty, fn) =>
-      isNothing()
-        ? isEmpty
-        : fn(contents)
-  )
-
-  return {
-    isNothing,
-    map,
-    open
-  }
+export function Maybe (x) {
+  this.x = x
 }
 
-export default maybe
+export function Nothing () {
+  Maybe.call(this, Null)
+  this.toString = () => 'Nothing'
+}
+Nothing.prototype = Object.create(Maybe.prototype)
+Nothing.prototype.constructor = Nothing
+Nothing.prototype.map = () => nothing
+
+export function Just (x) {
+  // For convenience, fail silently by converting to Nothing
+  if (x === null || x === undefined) {
+    return nothing
+  }
+  Maybe.call(this, x)
+  this.toString = () => `Just(${this.x})`
+}
+Just.prototype = Object.create(Maybe.prototype)
+Just.prototype.constructor = Just
+Just.prototype.map = function (f) {
+  const y = f(this.x)
+  return (y === null || y === undefined)
+    ? nothing
+    : new Just(y)
+}
+
+export const just = x => new Just(x)
+export const isJust = m => m instanceof Just
+
+export const nothing = new Nothing()
+export const isNothing = m => m instanceof Nothing
+
+export const maybe = curry((fallback, f, maybeInstance) =>
+  isNothing(maybeInstance)
+    ? fallback
+    : f(maybeInstance.x))

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,43 +1,40 @@
 import curry from './curry.mjs'
 
-export const Null = Object.freeze(Object.create(null))
-
-export function Maybe (x) {
-  this.x = x
-}
-
-export function Nothing () {
-  Maybe.call(this, Null)
-  this.toString = () => 'Nothing'
-}
-Nothing.prototype = Object.create(Maybe.prototype)
-Nothing.prototype.constructor = Nothing
-Nothing.prototype.map = () => nothing
-
-export function Just (x) {
-  // For convenience, fail silently by converting to Nothing
-  if (x === null || x === undefined) {
-    return nothing
+const isNull = x => x === undefined || x === null
+const trycatch = f => {
+  try {
+    return f()
+  } catch (e) {
+    return null
   }
-  Maybe.call(this, x)
-  this.toString = () => `Just(${this.x})`
-}
-Just.prototype = Object.create(Maybe.prototype)
-Just.prototype.constructor = Just
-Just.prototype.map = function (f) {
-  const y = f(this.x)
-  return (y === null || y === undefined)
-    ? nothing
-    : new Just(y)
 }
 
-export const just = x => new Just(x)
-export const isJust = m => m instanceof Just
+export const nothing = Object.freeze({
+  map: () => nothing,
+  join: () => nothing,
+  chain: () => nothing
+})
 
-export const nothing = new Nothing()
-export const isNothing = m => m instanceof Nothing
+export const just = x => ({
+  isJust: true,
+  map: f => {
+    const y = trycatch(() => f(x))
+    return isNull(y) ? nothing : just(y)
+  },
+  join: () => x,
+  chain: f => just(x).map(f).join()
+})
 
-export const maybe = curry((fallback, f, maybeInstance) =>
-  isNothing(maybeInstance)
-    ? fallback
-    : f(maybeInstance.x))
+export const isNothing = m => m === nothing
+export const isJust = m => !!m.isJust
+export const isMaybe = m => isNothing(m) || isJust(m)
+
+export const fromMaybe = curry((fallback, m) =>
+  isNothing(m) ? fallback : m.join())
+
+export const maybe = curry((fallback, f, m) => {
+  const y = m.chain(f)
+  return isNothing(y) ? fallback : y
+})
+
+export const catMaybes = xs => xs.filter(isJust)

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,46 +1,35 @@
 const load = require('@std/esm')(module)
 const test = require('ava')
-const maybe = load('./maybe.mjs').default
-const curry = load('./curry.mjs').default
+const {
+  isJust,
+  isNothing,
+  just,
+  nothing,
+  maybe,
+  Maybe
+} = load('./maybe.mjs')
 
-test('maybe.open', t => {
-  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
-  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+const id = x => x
+
+test('nothing', t => {
+  t.is(nothing instanceof Maybe, true, 'is a Maybe')
+  t.is(isNothing(nothing), true, 'is nothing')
+  t.is(isJust(nothing), false, 'is not a just')
+  t.is(isNothing(nothing.map(id)), true, 'maps back to a Nothing')
 })
 
-test('maybe.isNothing', t => {
-  t.is(maybe(4).isNothing(), false, 'a value is something')
-  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
-  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
-  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
-  t.is(maybe(null).isNothing(), true, 'null is nothing')
-  t.is(maybe().isNothing(), true, 'undefined is nothing')
+test('just', t => {
+  t.is(just(1) instanceof Maybe, true, 'is a Maybe')
+  t.is(isNothing(just(2)), false, 'is not nothing')
+  t.is(isJust(just(3)), true, 'is a just')
+  t.is(isNothing(just(null)), true, 'converts bad Just to a Nothing')
+  t.is(isJust(just(4).map(id)), true, 'maps to a Just for good fn return')
+  t.is(isJust(just(5).map(id)), true, 'maps back to a Just for good value')
+  t.is(isNothing(just(6).map(() => null)), true, 'maps to Nothing for bad fn return')
 })
 
-test('maybe map', t => {
-  const add = curry((a, b) => a + b)
-
-  t.is(
-    maybe(5)
-      .map(add(10))
-      .open('isEmpty', x => x),
-    15,
-    'mapping functions should create a new maybe'
-  )
-
-  t.is(
-    maybe(2)
-      .map(add(1))
-      .open('isEmpty', x => x),
-    3,
-    'mapping functions should create an new maybe'
-  )
-
-  t.is(
-    maybe()
-      .map(add(4))
-      .open('isEmpty', x => x),
-    'isEmpty',
-    'mapping nothing should return maybe nothing'
-  )
+test('maybe', t => {
+  t.is(maybe(0, id, nothing), 0, 'resolves nothing to fallback value')
+  t.is(maybe(0)(id)(nothing), 0, 'is curried')
+  t.is(maybe(0, id, just(42)), 42, 'resolves just to result of fn called with internal value')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -65,7 +65,6 @@ test('catMaybes', t => {
   const justs = catMaybes(list)
   const expected = [ 1, 2, 'test' ]
   t.is(justs.length, 3, 'returns list with only justs')
-  console.log(justs)
   justs.map((j, i) => {
     t.is(isJust(j), true, 'is a just')
     t.is(j.join(), expected[i], 'contains expected value')

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,35 +1,73 @@
 const load = require('@std/esm')(module)
 const test = require('ava')
 const {
+  catMaybes,
+  fromMaybe,
   isJust,
+  isMaybe,
   isNothing,
   just,
-  nothing,
   maybe,
-  Maybe
+  nothing
 } = load('./maybe.mjs')
 
 const id = x => x
+const add1 = x => x + 1
 
 test('nothing', t => {
-  t.is(nothing instanceof Maybe, true, 'is a Maybe')
   t.is(isNothing(nothing), true, 'is nothing')
+  t.is(isMaybe(nothing), true, 'is a maybe')
   t.is(isJust(nothing), false, 'is not a just')
-  t.is(isNothing(nothing.map(id)), true, 'maps back to a Nothing')
+
+  t.is(isNothing(nothing.map(id)), true, 'maps back to nothing')
+  t.is(isNothing(nothing.join(id)), true, 'joins back to nothing')
+  t.is(isNothing(nothing.chain(id)), true, 'chains back to nothing')
 })
 
 test('just', t => {
-  t.is(just(1) instanceof Maybe, true, 'is a Maybe')
-  t.is(isNothing(just(2)), false, 'is not nothing')
-  t.is(isJust(just(3)), true, 'is a just')
-  t.is(isNothing(just(null)), true, 'converts bad Just to a Nothing')
-  t.is(isJust(just(4).map(id)), true, 'maps to a Just for good fn return')
-  t.is(isJust(just(5).map(id)), true, 'maps back to a Just for good value')
-  t.is(isNothing(just(6).map(() => null)), true, 'maps to Nothing for bad fn return')
+  t.is(isJust(just(1)), true, 'is a just')
+  t.is(isMaybe(just(2)), true, 'is a maybe')
+  t.is(isNothing(just(3)), false, 'is not nothing')
+
+  t.is(just(4).join(), 4, 'joins to internal value')
+
+  t.is(isJust(just(5).map(id)), true, 'maps to a just for valid return')
+  t.is(just(6).map(add1).join(), 7, 'maps to a just containing result')
+  t.is(isNothing(just(8).map(() => null)), true, 'maps to nothing for null return')
+  t.is(just(9).map(x => just(x)).join().join(), 9, 'maps returned just to nested justs')
+
+  t.is(just(10).chain(add1), 11, 'chains to result for valid function return')
+  t.is(just(12).chain(x => just(x)).join(), 12, 'chain flattens 1 layer of nested justs')
+  t.is(isNothing(just(13).chain(() => null)), true, 'joins to nothing for null return')
 })
 
 test('maybe', t => {
   t.is(maybe(0, id, nothing), 0, 'resolves nothing to fallback value')
   t.is(maybe(0)(id)(nothing), 0, 'is curried')
-  t.is(maybe(0, id, just(42)), 42, 'resolves just to result of fn called with internal value')
+  t.is(maybe(0, add1, just(42)), 43, 'resolves just to result of fn called with internal value')
+})
+
+test('fromMaybe', t => {
+  t.is(fromMaybe('default', nothing), 'default', 'resolves nothing to fallback value')
+  t.is(fromMaybe('default')(nothing), 'default', 'is curried')
+  t.is(fromMaybe('default', just(52)), 52, 'resolves just to its internal value')
+})
+
+test('catMaybes', t => {
+  const list = [
+    nothing,
+    just(1),
+    nothing,
+    just(2),
+    nothing,
+    just('test')
+  ]
+  const justs = catMaybes(list)
+  const expected = [ 1, 2, 'test' ]
+  t.is(justs.length, 3, 'returns list with only justs')
+  console.log(justs)
+  justs.map((j, i) => {
+    t.is(isJust(j), true, 'is a just')
+    t.is(j.join(), expected[i], 'contains expected value')
+  })
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,0 +1,46 @@
+const load = require('@std/esm')(module)
+const test = require('ava')
+const maybe = load('./maybe.mjs').default
+const curry = load('./curry.mjs').default
+
+test('maybe.open', t => {
+  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
+  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+})
+
+test('maybe.isNothing', t => {
+  t.is(maybe(4).isNothing(), false, 'a value is something')
+  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
+  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
+  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
+  t.is(maybe(null).isNothing(), true, 'null is nothing')
+  t.is(maybe().isNothing(), true, 'undefined is nothing')
+})
+
+test('maybe map', t => {
+  const add = curry((a, b) => a + b)
+
+  t.is(
+    maybe(5)
+      .map(add(10))
+      .open('isEmpty', x => x),
+    15,
+    'mapping functions should create a new maybe'
+  )
+
+  t.is(
+    maybe(2)
+      .map(add(1))
+      .open('isEmpty', x => x),
+    3,
+    'mapping functions should create an new maybe'
+  )
+
+  t.is(
+    maybe()
+      .map(add(4))
+      .open('isEmpty', x => x),
+    'isEmpty',
+    'mapping nothing should return maybe nothing'
+  )
+})


### PR DESCRIPTION
Here is another attempt at Maybe, this time with just some objects and helper functions.

"Maybe" itself becomes only an abstract idea that mentally captures either Nothing or Just. I rather like this result, but the possibility of real type checking is out the window.

This example is a bit more complete than the class example because I wasn't distracted by class boilerplate and I needed to implement the `join` method before I could test the internal values.