### PR TITLE
Fixes #19 by removing interal curry from compose.

### DIFF
--- a/lib/compose.mjs
+++ b/lib/compose.mjs
@@ -1,7 +1,5 @@
-import curry from './curry.mjs'
-
 const compose = (...args) =>
   (...moreArgs) =>
-    args.reduceRight((value, fn) => curry(fn)(value), ...moreArgs)
+    args.reduceRight((value, fn) => fn(value), ...moreArgs)
 
 export default compose

--- a/lib/compose.test.js
+++ b/lib/compose.test.js
@@ -4,8 +4,16 @@ const compose = load('./compose.mjs').default
 
 const greet = name => `Hello ${name}.`
 const exclaim = message => message.toUpperCase()
+const id = a => a
+const ignoreAllButFirstArg = (a, b, c, d, e) => a
+const toArray = (...args) => args
 
 test('compose', t => {
   t.is(compose(exclaim, greet)('Bob'), 'HELLO BOB.')
   t.is(compose(greet, exclaim)('Jeff'), 'Hello JEFF.')
+
+  t.deepEqual(compose(toArray, id)(1), [1],
+    'handles functions with rest parameter ')
+  t.is(compose(id, ignoreAllButFirstArg)(1), 1,
+    'handles functions with multiple arguments in signature')
 })


### PR DESCRIPTION
Internal use of currying is of minimal benefit for compose. It adds unnecessary overhead and completely chokes in the case of optionally-unary functions. This patch removes the automatic internal curry and adds tests for proper handling of unary-like multi-parameter functions and for rest parameter functions.