### PR TITLE
Fixes #14 by adding flipAll 

### DIFF
--- a/lib/flip.test.js
+++ b/lib/flip.test.js
@@ -3,11 +3,14 @@ const test = require('ava')
 const flip = load('./flip.mjs').default
 
 const add = (a, b) => a + b
+const add4 = (a, b, c, d) => a + b + c + d
 
 test('flip', t => {
-  t.is(flip(add)('x')('y'), 'yx', 'should work passing argument in individually')
-  t.is(flip(add, 'a', 'b'), 'ba', 'should work passing all arguments at once')
-  t.is(flip(add, 'c')('d'), 'dc', 'should work passing some arguments straight away')
-  t.is(flip(add)('e', 'f'), 'fe', 'should work passing in arguments later')
-  t.is(flip(add, 'x', 'y', 'z'), 'yx', 'should ignore additional arguments')
+  t.is(flip(add)('x')('y'), 'yx', 'flips after accepting individual arguments')
+  t.is(flip(add, 'a', 'b'), 'ba', 'flips after accepting all arguments at once')
+  t.is(flip(add, 'c')('d'), 'dc', 'flips after accepting some arguments straight away')
+  t.is(flip(add)('e', 'f'), 'fe', 'flips after only function first, with batched arugments later')
+  t.is(flip(add, 'x', 'y', 'z'), 'yx', 'ignores extraneous arguments')
+
+  t.is(flip(add4)('a', 'b', 'c', 'd'), 'bacd', 'flips only first two arguments')
 })

--- a/lib/flipAll.mjs
+++ b/lib/flipAll.mjs
@@ -1,6 +1,6 @@
 const flip = (fn, ...args) =>
   args.length >= fn.length
-    ? fn(...args.slice(0, 2).reverse(), ...args.slice(2, fn.length))
+    ? fn(...args.slice(0, fn.length).reverse())
     : (...moreArgs) => flip(fn, ...args, ...moreArgs)
 
 export default flip

--- a/lib/flipAll.test.js
+++ b/lib/flipAll.test.js
@@ -1,0 +1,16 @@
+const load = require('@std/esm')(module)
+const test = require('ava')
+const flipAll = load('./flipAll.mjs').default
+
+const add = (a, b) => a + b
+const add4 = (a, b, c, d) => a + b + c + d
+
+test('flipAll', t => {
+  t.is(flipAll(add)('x')('y'), 'yx', 'flips after accepting individual arguments')
+  t.is(flipAll(add, 'a', 'b'), 'ba', 'flips after accepting all arguments at once')
+  t.is(flipAll(add, 'c')('d'), 'dc', 'flips after accepting some arguments straight away')
+  t.is(flipAll(add)('e', 'f'), 'fe', 'flips after only function first, with batched arugments later')
+  t.is(flipAll(add, 'x', 'y', 'z'), 'yx', 'ignores extraneous arguments')
+
+  t.is(flipAll(add4)('a', 'b', 'c', 'd'), 'dcba', 'flips entire parameter list')
+})


### PR DESCRIPTION
Moves the current flip implementation, which acts on all parameters to flipAll. Replaces flip with the commonly expected variation, which only flips two arugments.