### PR TITLE
Fixes #22 by removing interal curry from pipe.

### DIFF
--- a/lib/pipe.mjs
+++ b/lib/pipe.mjs
@@ -1,7 +1,5 @@
-import curry from './curry.mjs'
-
 const pipe = (...args) =>
   (...moreArgs) =>
-    args.reduce((value, fn) => curry(fn)(value), ...moreArgs)
+    args.reduce((value, fn) => fn(value), ...moreArgs)
 
 export default pipe

--- a/lib/pipe.test.js
+++ b/lib/pipe.test.js
@@ -4,8 +4,16 @@ const pipe = load('./pipe.mjs').default
 
 const greet = name => `Hello ${name}.`
 const exclaim = message => message.toUpperCase()
+const id = a => a
+const ignoreAllButFirstArg = (a, b, c, d, e) => a
+const toArray = (...args) => args
 
 test('compose', t => {
   t.is(pipe(greet, exclaim)('Bob'), 'HELLO BOB.')
   t.is(pipe(exclaim, greet)('Jeff'), 'Hello JEFF.')
+
+  t.deepEqual(pipe(id, toArray)(1), [1],
+    'handles functions with rest parameter ')
+  t.is(pipe(ignoreAllButFirstArg, id)(1), 1,
+    'handles functions with multiple arguments in signature')
 })


### PR DESCRIPTION
Remove internal automatic currying from pipe. Add tests for proper handling of unary-like multi-parameter functions and for rest parameter functions.