### PR TITLE
Add map and chain to maybes

### DIFF
--- a/lib/maybe.doc.md
+++ b/lib/maybe.doc.md
@@ -3,15 +3,13 @@
 A `maybe` function is created by a `just` or a `nothing` function. It is used when there is a possibility that you may not have any data.
 
 ```javascript
-import {just} from 'ln-f'
+import {maybe, just, nothing} from 'ln-f'
 
-const maybe4 = just(4)
+const maybeNumberResolver = maybe('is not a number', number => `number: ${number}`)
 
-maybe4('no value', value => `set to ${value}`) // set to 4
+maybeNumberResolver(just(4))    // number: 4
+maybeNumberResolver(nothing())  // is not a number
 
-const maybeNothing = nothing()
-
-maybeNothing('empty', value => 'not empty') // empty
 ```
 
 # In the real world
@@ -26,51 +24,30 @@ const users = [
   },
   {
     name: 'Sarah'
-    // no nickname... this could cause problems
   }
 ```
 
-Later we want to greet the user by nickname
+We can create resolver with a `maybe` function that will output a predictable result in either case.
 
 ```javascript
-const greet = user => `Hello ${user.nickname}!`
+const greet = maybe('Hi there!', nickname => `Hello ${user.nickname}!`)
 
-greet(users[0]) // Hello Fluffy!
-greet(users[1]) // Hello undefined!
+users.map(user => greet(user.nickname)) // ['Hello Fluffy!', 'Hi there!']
 ```
-
-Now lets see what it would look like with a maybe.
-
-```javascript
-// lets just convert the existing users for now
-const safeUsers = users.map(user => {
-  return {
-    name: user.name,
-    nickname: user.nickname ? just(user.nickname) : nothing()
-  }
-})
-
-// now lets re-write the greet function to work with a maybe
-const safeGreet = user => user.nickname('Hi there!', value => `Hey ${value}!`)
-
-greet(users[0]) // Hey Fluffy!
-greet(users[1]) // Hi there!
-```
-
-There is a little extra work, but in the long run by seeing a maybe function, we can handle this case early (not when the users spot an issue).
 
 # How it works
 
-By wrapping a value in either `just` or `nothing` we get the same `maybe` function back that we can pass around, and output when we need it.
+By wrapping a value in either `just` or `nothing` we can use a `maybe` function to resolve the value.
 
 ```javascript
-const add10Years = maybe => maybe(nothing(), value => just(value + 10))
+const add10Years = maybe(nothing(), value => just(value + 10))
+const getMyAge = maybe('I cannot tell you', age => `${age} years`)
 
 const myAge = just(20) // maybe 20
 const myAgeIn10Years = add10Years(myAge) // maybe 30
-const happyResult = myAgeIn10Years('I cannot tell you', age => `${age} years`) // 30 years
+const happyResult = getMyAge(myAgeIn10Years) // 30 years
 
-const noAge = nothing()
-const noAgeIn10Years = add10Years(noAge)
-const unhappyResult = noAgeIn10Years('I cannot tell you', age => `${age} years`) // I cannot tell you
+const noAge = nothing() // maybe nothing
+const noAgeIn10Years = add10Years(noAge) // maybe nothing
+const unhappyResult = getMyAge(noAgeIn10Years) // I cannot tell you
 ```

--- a/lib/maybe.doc.md
+++ b/lib/maybe.doc.md
@@ -1,0 +1,76 @@
+# maybe (just, nothing)
+
+A `maybe` function is created by a `just` or a `nothing` function. It is used when there is a possibility that you may not have any data.
+
+```javascript
+import {just} from 'ln-f'
+
+const maybe4 = just(4)
+
+maybe4('no value', value => `set to ${value}`) // set to 4
+
+const maybeNothing = nothing()
+
+maybeNothing('empty', value => 'not empty') // empty
+```
+
+# In the real world
+
+Whenever you may have incomplete data you can use a maybe. Let's say that a user fills out a profile by decides not to fill out an optional value such a nickname. You could end up with a table of users such as the following:
+
+```javascript
+const users = [
+  {
+    name: 'Bob',
+    nickname: 'Fluffy'
+  },
+  {
+    name: 'Sarah'
+    // no nickname... this could cause problems
+  }
+```
+
+Later we want to greet the user by nickname
+
+```javascript
+const greet = user => `Hello ${user.nickname}!`
+
+greet(users[0]) // Hello Fluffy!
+greet(users[1]) // Hello undefined!
+```
+
+Now lets see what it would look like with a maybe.
+
+```javascript
+// lets just convert the existing users for now
+const safeUsers = users.map(user => {
+  return {
+    name: user.name,
+    nickname: user.nickname ? just(user.nickname) : nothing()
+  }
+})
+
+// now lets re-write the greet function to work with a maybe
+const safeGreet = user => user.nickname('Hi there!', value => `Hey ${value}!`)
+
+greet(users[0]) // Hey Fluffy!
+greet(users[1]) // Hi there!
+```
+
+There is a little extra work, but in the long run by seeing a maybe function, we can handle this case early (not when the users spot an issue).
+
+# How it works
+
+By wrapping a value in either `just` or `nothing` we get the same `maybe` function back that we can pass around, and output when we need it.
+
+```javascript
+const add10Years = maybe => maybe(nothing(), value => just(value + 10))
+
+const myAge = just(20) // maybe 20
+const myAgeIn10Years = add10Years(myAge) // maybe 30
+const happyResult = myAgeIn10Years('I cannot tell you', age => `${age} years`) // 30 years
+
+const noAge = nothing()
+const noAgeIn10Years = add10Years(noAge)
+const unhappyResult = noAgeIn10Years('I cannot tell you', age => `${age} years`) // I cannot tell you
+```

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,10 +1,18 @@
 const JUST = 'JUST'
 const NOTHING = 'NOTHING'
 
-const maybe = aMaybe => (errorValue, successFn) => {
+// TODO move into utilities module
+const isRequired = type => {
+  throw new Error(`Error: expected to receive ${type} argument`)
+}
+
+const maybe = aMaybe => (
+  errorValue = isRequired('errorValue'),
+  successCallback = isRequired('successCallback')
+) => {
   switch (aMaybe.type) {
     case JUST:
-      return successFn(aMaybe.value)
+      return successCallback(aMaybe.value)
     case NOTHING:
     default:
       return errorValue

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,0 +1,26 @@
+import curry from './curry.mjs'
+
+const maybe = x => {
+  const contents = x
+
+  const isNothing = () =>
+    contents === null || contents === undefined
+
+  const map = fn =>
+    maybe(isNothing() ? null : fn(contents))
+
+  const open = curry(
+    (isEmpty, fn) =>
+      isNothing()
+        ? isEmpty
+        : fn(contents)
+  )
+
+  return {
+    isNothing,
+    map,
+    open
+  }
+}
+
+export default maybe

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,23 +1,29 @@
+import curry from './curry'
+
 const JUST = 'JUST'
 const NOTHING = 'NOTHING'
 
-export const maybe = (errorValue = '[nothing]', successCallback) => aMaybe => {
+export const maybe = (defaultValue = '[nothing]', successCallback) => aMaybe => {
   switch (aMaybe.type) {
     case JUST:
       return successCallback(aMaybe.value)
     case NOTHING:
     default:
-      return errorValue
+      return defaultValue
   }
 }
 
 export const just = value =>
   ({
     value,
-    type: JUST
+    type: JUST,
+    map: f => just(f(value)),
+    chain: f => f(value)
   })
 
 export const nothing = _ =>
   ({
-    type: NOTHING
+    type: NOTHING,
+    map: _ => nothing,
+    chain: _ => nothing
   })

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,26 +1,24 @@
-import curry from './curry.mjs'
+const JUST = 'JUST'
+const NOTHING = 'NOTHING'
 
-const maybe = x => {
-  const contents = x
-
-  const isNothing = () =>
-    contents === null || contents === undefined
-
-  const map = fn =>
-    maybe(isNothing() ? null : fn(contents))
-
-  const open = curry(
-    (isEmpty, fn) =>
-      isNothing()
-        ? isEmpty
-        : fn(contents)
-  )
-
-  return {
-    isNothing,
-    map,
-    open
+const maybe = aMaybe => (errorValue, successFn) => {
+  switch (aMaybe.type) {
+    case JUST:
+      return successFn(aMaybe.value)
+    case NOTHING:
+    default:
+      return errorValue
   }
 }
 
-export default maybe
+// just :: a -> Maybe a
+export const just = value =>
+  value === null || value === undefined
+    ? nothing()
+    : maybe({value, type: JUST})
+
+// nothing :: _ -> Maybe Nothing
+export const nothing = _ =>
+  maybe({
+    type: NOTHING
+  })

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,7 +1,7 @@
 const JUST = 'JUST'
 const NOTHING = 'NOTHING'
 
-const maybe = aMaybe => (errorValue = '[nothing]', successCallback) => {
+export const maybe = (errorValue = '[nothing]', successCallback) => aMaybe => {
   switch (aMaybe.type) {
     case JUST:
       return successCallback(aMaybe.value)
@@ -11,15 +11,13 @@ const maybe = aMaybe => (errorValue = '[nothing]', successCallback) => {
   }
 }
 
-// just :: a -> Maybe a
 export const just = value =>
-  maybe({
+  ({
     value,
     type: JUST
   })
 
-// nothing :: _ -> Maybe Nothing
 export const nothing = _ =>
-  maybe({
+  ({
     type: NOTHING
   })

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,15 +1,7 @@
 const JUST = 'JUST'
 const NOTHING = 'NOTHING'
 
-// TODO move into utilities module
-const isRequired = type => {
-  throw new Error(`Error: expected to receive ${type} argument`)
-}
-
-const maybe = aMaybe => (
-  errorValue = isRequired('errorValue'),
-  successCallback = isRequired('successCallback')
-) => {
+const maybe = aMaybe => (errorValue = '[nothing]', successCallback) => {
   switch (aMaybe.type) {
     case JUST:
       return successCallback(aMaybe.value)
@@ -21,9 +13,10 @@ const maybe = aMaybe => (
 
 // just :: a -> Maybe a
 export const just = value =>
-  value === null || value === undefined
-    ? nothing()
-    : maybe({value, type: JUST})
+  maybe({
+    value,
+    type: JUST
+  })
 
 // nothing :: _ -> Maybe Nothing
 export const nothing = _ =>

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -2,11 +2,35 @@ const load = require('@std/esm')(module)
 const test = require('ava')
 const {just, nothing, maybe} = load('./maybe.mjs')
 
-test('maybe', t => {
-  const errorValue = 'nothing to see'
-  const successFn = value => value
-  const maybeResolver = maybe(errorValue, successFn)
+test.serial('maybe', t => {
+  const defaultValue = 'nothing to see'
+  const justApplicator = value => value
+  const maybeResolver = maybe(defaultValue, justApplicator)
 
   t.is(maybeResolver(just(3)), 3)
   t.is(maybeResolver(nothing()), 'nothing to see')
+})
+
+const defaultValue = 'nothing to see'
+const justApplicator = value => value
+const maybeResolver = maybe(defaultValue, justApplicator)
+
+test('map', t => {
+  const just2 = just(2)
+  const nil = nothing()
+  const add1 = number => number + 1
+
+  t.is(maybeResolver(just2.map(add1)), 3)
+  t.is(maybeResolver(nil.map(add1)), 'nothing to see')
+})
+
+test('chain', t => {
+  const justHello = just('hello')
+  const nil = nothing()
+
+  const toUpperMaybe = string => just(string.toUpperCase())
+  const returnNothing = _ => nothing()
+
+  t.is(maybeResolver(justHello.chain(toUpperMaybe)), 'HELLO')
+  t.is(maybeResolver(nil.chain(returnNothing)), 'nothing to see')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,46 +1,28 @@
 const load = require('@std/esm')(module)
 const test = require('ava')
-const maybe = load('./maybe.mjs').default
-const curry = load('./curry.mjs').default
+const {just, nothing} = load('./maybe.mjs')
 
-test('maybe.open', t => {
-  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
-  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+test('just', t => {
+  t.is(typeof just(4), 'function', 'should return maybe function')
 })
 
-test('maybe.isNothing', t => {
-  t.is(maybe(4).isNothing(), false, 'a value is something')
-  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
-  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
-  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
-  t.is(maybe(null).isNothing(), true, 'null is nothing')
-  t.is(maybe().isNothing(), true, 'undefined is nothing')
+test('nothing', t => {
+  t.is(typeof nothing(), 'function', 'should return maybe function')
 })
 
-test('maybe map', t => {
-  const add = curry((a, b) => a + b)
+test('maybe', t => {
+  const errorValue = 'nothing to see'
+  const successFn = value => value
 
-  t.is(
-    maybe(5)
-      .map(add(10))
-      .open('isEmpty', x => x),
-    15,
-    'mapping functions should create a new maybe'
-  )
+  const maybe3 = just(3)
+  t.is(maybe3(errorValue, successFn), 3)
 
-  t.is(
-    maybe(2)
-      .map(add(1))
-      .open('isEmpty', x => x),
-    3,
-    'mapping functions should create an new maybe'
-  )
+  const maybeNothing = nothing()
+  t.is(maybeNothing(errorValue, successFn), 'nothing to see')
 
-  t.is(
-    maybe()
-      .map(add(4))
-      .open('isEmpty', x => x),
-    'isEmpty',
-    'mapping nothing should return maybe nothing'
-  )
+  const maybeSomething = just()
+  t.is(maybeSomething(errorValue, successFn), 'nothing to see')
 })
+
+// just map
+// nothing map

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,43 +1,12 @@
 const load = require('@std/esm')(module)
 const test = require('ava')
-const {just, nothing} = load('./maybe.mjs')
-
-test('just', t => {
-  t.is(typeof just(4), 'function', 'should return maybe function')
-})
-
-test('nothing', t => {
-  t.is(typeof nothing(), 'function', 'should return maybe function')
-})
+const {just, nothing, maybe} = load('./maybe.mjs')
 
 test('maybe', t => {
   const errorValue = 'nothing to see'
   const successFn = value => value
+  const maybeResolver = maybe(errorValue, successFn)
 
-  const maybe3 = just(3)
-  t.is(maybe3(errorValue, successFn), 3)
-
-  const maybeNothing = nothing()
-  t.is(maybeNothing(errorValue, successFn), 'nothing to see')
-
-  const maybeSomething = just()
-  t.is(maybeSomething(errorValue, successFn), 'nothing to see')
-})
-
-test('maybe without required fields', t => {
-  const just4 = just(4)
-
-  t.throws(
-    () => {
-      just4() // not passing in errorValue
-    },
-    'Error: expected to receive errorValue argument'
-  )
-
-  t.throws(
-    () => {
-      just4('isEmpty') // not passing in a success callback
-    },
-    'Error: expected to receive successCallback argument'
-  )
+  t.is(maybeResolver(just(3)), 3)
+  t.is(maybeResolver(nothing()), 'nothing to see')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -1,0 +1,46 @@
+const load = require('@std/esm')(module)
+const test = require('ava')
+const maybe = load('./maybe.mjs').default
+const curry = load('./curry.mjs').default
+
+test('maybe.open', t => {
+  t.is(maybe(4).open('isEmpty', x => x), 4, 'should process the value')
+  t.is(maybe().open('isEmpty', x => x), 'isEmpty', 'should return empty option')
+})
+
+test('maybe.isNothing', t => {
+  t.is(maybe(4).isNothing(), false, 'a value is something')
+  t.is(maybe(0).isNothing(), false, '0 is a value which is something')
+  t.is(maybe(false).isNothing(), false, 'false is a value which is something')
+  t.is(maybe(undefined).isNothing(), true, 'undefined is nothing')
+  t.is(maybe(null).isNothing(), true, 'null is nothing')
+  t.is(maybe().isNothing(), true, 'undefined is nothing')
+})
+
+test('maybe map', t => {
+  const add = curry((a, b) => a + b)
+
+  t.is(
+    maybe(5)
+      .map(add(10))
+      .open('isEmpty', x => x),
+    15,
+    'mapping functions should create a new maybe'
+  )
+
+  t.is(
+    maybe(2)
+      .map(add(1))
+      .open('isEmpty', x => x),
+    3,
+    'mapping functions should create an new maybe'
+  )
+
+  t.is(
+    maybe()
+      .map(add(4))
+      .open('isEmpty', x => x),
+    'isEmpty',
+    'mapping nothing should return maybe nothing'
+  )
+})

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -24,5 +24,20 @@ test('maybe', t => {
   t.is(maybeSomething(errorValue, successFn), 'nothing to see')
 })
 
-// just map
-// nothing map
+test('maybe without required fields', t => {
+  const just4 = just(4)
+
+  t.throws(
+    () => {
+      just4() // not passing in errorValue
+    },
+    'Error: expected to receive errorValue argument'
+  )
+
+  t.throws(
+    () => {
+      just4('isEmpty') // not passing in a success callback
+    },
+    'Error: expected to receive successCallback argument'
+  )
+})


### PR DESCRIPTION
Add map and chain to just and nothing.

Seems like this is working. One thing that's bothering me is how exposed everything is. Should a console log really dump out all the internals like this? We could hide most of this stuff by putting it on a prototype.

Also, with the current implementation, I'm not sure it's possible to do a true chain. I had to use a functionally equivalent shortcut.

```
console.log(just(2))
//  { 
//    value: 2,
//    type: 'JUST',
//    map: [Function: map],
//    chain: [Function: chain]
//  }

```