### PR TITLE
Add map and chain to maybes

### DIFF
--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,23 +1,29 @@
+import curry from './curry'
+
 const JUST = 'JUST'
 const NOTHING = 'NOTHING'
 
-export const maybe = (errorValue = '[nothing]', successCallback) => aMaybe => {
+export const maybe = (defaultValue = '[nothing]', successCallback) => aMaybe => {
   switch (aMaybe.type) {
     case JUST:
       return successCallback(aMaybe.value)
     case NOTHING:
     default:
-      return errorValue
+      return defaultValue
   }
 }
 
 export const just = value =>
   ({
     value,
-    type: JUST
+    type: JUST,
+    map: f => just(f(value)),
+    chain: f => f(value)
   })
 
 export const nothing = _ =>
   ({
-    type: NOTHING
+    type: NOTHING,
+    map: _ => nothing,
+    chain: _ => nothing
   })

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,29 +1,25 @@
-import curry from './curry'
-
-const JUST = 'JUST'
-const NOTHING = 'NOTHING'
+const justValues = new Map()
 
 export const maybe = (defaultValue = '[nothing]', successCallback) => aMaybe => {
-  switch (aMaybe.type) {
-    case JUST:
-      return successCallback(aMaybe.value)
-    case NOTHING:
-    default:
-      return defaultValue
+  const isJust = justValues.get(aMaybe)
+
+  if (!isJust) {
+    return defaultValue
   }
+
+  justValues.delete(aMaybe)
+  return successCallback(isJust)
 }
 
-export const just = value =>
-  ({
-    value,
-    type: JUST,
-    map: f => just(f(value)),
-    chain: f => f(value)
-  })
+export const just = value => {
+  const key = {
+    map: fn => just(fn(value))
+  }
+  justValues.set(key, value)
+  return key
+}
 
 export const nothing = _ =>
   ({
-    type: NOTHING,
-    map: _ => nothing,
-    chain: _ => nothing
+    map: _ => nothing()
   })

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,21 +1,22 @@
 import curry from './curry'
 
-export const maybe = curry((defaultValue, callback, aMaybe) =>
-  aMaybe instanceof Just
-    ? callback(aMaybe.value)
-    : defaultValue
-)
+export const maybe = curry((defaultValue, callback, aMaybe) => {
+  const value = aMaybe.chain && aMaybe.chain(x => x)
+  return (value === nothing || aMaybe instanceof Maybe === false)
+    ? defaultValue
+    : callback(value)
+})
 
-export const just = value => new Just(value)
+export function Maybe () {}
 
-function Just (value) { this.value = value }
+export const just = x => Object.create(Maybe.prototype, {
+  contents: { enumerable: true, value: `Just(${x})` },
+  map: { value: f => just(f(x)) },
+  chain: { value: f => f(x) }
+})
 
-Just.prototype.map = function (f) { return just(f(this.value)) }
-Just.prototype.chain = function (f) { return f(this.value) }
-
-export const nothing = () => new Nothing()
-
-function Nothing () {}
-
-Nothing.prototype.map = _ => nothing()
-Nothing.prototype.chain = _ => nothing()
+export const nothing = Object.create(Maybe.prototype, {
+  contents: { enumerable: true, value: 'nothing' },
+  map: { value: _ => nothing },
+  chain: { value: _ => nothing }
+})

--- a/lib/maybe.mjs
+++ b/lib/maybe.mjs
@@ -1,25 +1,21 @@
-const justValues = new Map()
+import curry from './curry'
 
-export const maybe = (defaultValue = '[nothing]', successCallback) => aMaybe => {
-  const isJust = justValues.get(aMaybe)
+export const maybe = curry((defaultValue, callback, aMaybe) =>
+  aMaybe instanceof Just
+    ? callback(aMaybe.value)
+    : defaultValue
+)
 
-  if (!isJust) {
-    return defaultValue
-  }
+export const just = value => new Just(value)
 
-  justValues.delete(aMaybe)
-  return successCallback(isJust)
-}
+function Just (value) { this.value = value }
 
-export const just = value => {
-  const key = {
-    map: fn => just(fn(value))
-  }
-  justValues.set(key, value)
-  return key
-}
+Just.prototype.map = function (f) { return just(f(this.value)) }
+Just.prototype.chain = function (f) { return f(this.value) }
 
-export const nothing = _ =>
-  ({
-    map: _ => nothing()
-  })
+export const nothing = () => new Nothing()
+
+function Nothing () {}
+
+Nothing.prototype.map = _ => nothing()
+Nothing.prototype.chain = _ => nothing()

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -2,11 +2,35 @@ const load = require('@std/esm')(module)
 const test = require('ava')
 const {just, nothing, maybe} = load('./maybe.mjs')
 
-test('maybe', t => {
-  const errorValue = 'nothing to see'
-  const successFn = value => value
-  const maybeResolver = maybe(errorValue, successFn)
+test.serial('maybe', t => {
+  const defaultValue = 'nothing to see'
+  const justApplicator = value => value
+  const maybeResolver = maybe(defaultValue, justApplicator)
 
   t.is(maybeResolver(just(3)), 3)
   t.is(maybeResolver(nothing()), 'nothing to see')
+})
+
+const defaultValue = 'nothing to see'
+const justApplicator = value => value
+const maybeResolver = maybe(defaultValue, justApplicator)
+
+test('map', t => {
+  const just2 = just(2)
+  const nil = nothing()
+  const add1 = number => number + 1
+
+  t.is(maybeResolver(just2.map(add1)), 3)
+  t.is(maybeResolver(nil.map(add1)), 'nothing to see')
+})
+
+test('chain', t => {
+  const justHello = just('hello')
+  const nil = nothing()
+
+  const toUpperMaybe = string => just(string.toUpperCase())
+  const returnNothing = _ => nothing()
+
+  t.is(maybeResolver(justHello.chain(toUpperMaybe)), 'HELLO')
+  t.is(maybeResolver(nil.chain(returnNothing)), 'nothing to see')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -2,35 +2,29 @@ const load = require('@std/esm')(module)
 const test = require('ava')
 const {just, nothing, maybe} = load('./maybe.mjs')
 
-test.serial('maybe', t => {
-  const defaultValue = 'nothing to see'
-  const justApplicator = value => value
-  const maybeResolver = maybe(defaultValue, justApplicator)
+test('just', t => {
+  t.is(typeof just(1), 'object')
+  t.is(typeof just(1).map, 'function')
+})
+
+test('nothing', t => {
+  t.is(typeof nothing(1), 'object')
+  t.is(typeof nothing(1).map, 'function')
+})
+
+test('maybe', t => {
+  const errorValue = 'nothing to see'
+  const successFn = value => value
+  const maybeResolver = maybe(errorValue, successFn)
 
   t.is(maybeResolver(just(3)), 3)
   t.is(maybeResolver(nothing()), 'nothing to see')
 })
 
-const defaultValue = 'nothing to see'
-const justApplicator = value => value
-const maybeResolver = maybe(defaultValue, justApplicator)
-
-test('map', t => {
-  const just2 = just(2)
-  const nil = nothing()
+test('maybe.map', t => {
   const add1 = number => number + 1
+  const maybeResolver = maybe('no value', x => x)
 
-  t.is(maybeResolver(just2.map(add1)), 3)
-  t.is(maybeResolver(nil.map(add1)), 'nothing to see')
-})
-
-test('chain', t => {
-  const justHello = just('hello')
-  const nil = nothing()
-
-  const toUpperMaybe = string => just(string.toUpperCase())
-  const returnNothing = _ => nothing()
-
-  t.is(maybeResolver(justHello.chain(toUpperMaybe)), 'HELLO')
-  t.is(maybeResolver(nil.chain(returnNothing)), 'nothing to see')
+  t.is(maybeResolver(just(2).map(add1)), 3)
+  t.is(maybeResolver(nothing().map(add1)), 'no value')
 })

--- a/lib/maybe.test.js
+++ b/lib/maybe.test.js
@@ -2,29 +2,33 @@ const load = require('@std/esm')(module)
 const test = require('ava')
 const {just, nothing, maybe} = load('./maybe.mjs')
 
-test('just', t => {
-  t.is(typeof just(1), 'object')
-  t.is(typeof just(1).map, 'function')
-})
-
-test('nothing', t => {
-  t.is(typeof nothing(1), 'object')
-  t.is(typeof nothing(1).map, 'function')
-})
-
-test('maybe', t => {
-  const errorValue = 'nothing to see'
-  const successFn = value => value
-  const maybeResolver = maybe(errorValue, successFn)
+test.serial('maybe', t => {
+  const defaultValue = 'nothing to see'
+  const justApplicator = value => value
+  const maybeResolver = maybe(defaultValue, justApplicator)
 
   t.is(maybeResolver(just(3)), 3)
-  t.is(maybeResolver(nothing()), 'nothing to see')
+  t.is(maybeResolver(nothing), 'nothing to see')
 })
 
-test('maybe.map', t => {
-  const add1 = number => number + 1
-  const maybeResolver = maybe('no value', x => x)
+const defaultValue = 'nothing to see'
+const justApplicator = value => value
+const maybeResolver = maybe(defaultValue, justApplicator)
 
-  t.is(maybeResolver(just(2).map(add1)), 3)
-  t.is(maybeResolver(nothing().map(add1)), 'no value')
+test('map', t => {
+  const just2 = just(2)
+  const add1 = number => number + 1
+
+  t.is(maybeResolver(just2.map(add1)), 3)
+  t.is(maybeResolver(nothing.map(add1)), 'nothing to see')
+})
+
+test('chain', t => {
+  const justHello = just('hello')
+
+  const toUpperMaybe = string => just(string.toUpperCase())
+  const returnNothing = _ => nothing
+
+  t.is(maybeResolver(justHello.chain(toUpperMaybe)), 'HELLO')
+  t.is(maybeResolver(nothing.chain(returnNothing)), 'nothing to see')
 })


### PR DESCRIPTION
* Add map and chain functions to nothing which just return nothing.

* Add map to just, which returns a just of the result of applying provided function to the just's value.

* Add chain to just, which returns the result of applying provided functionto the justs value. If user uses as intended by passing in a function that returns a maybe, then this is functionally equivalent to mapping over the justs value, followed by extracting out the nested maybe from the result.